### PR TITLE
typo in #include guards

### DIFF
--- a/include/libc/math/sqrtk/sqrtk.h
+++ b/include/libc/math/sqrtk/sqrtk.h
@@ -1,6 +1,6 @@
 #ifndef _LIBC_SQRTK_H_
-#define _LIBC_MATH_H_
+#define _LIBC_SQRTK_H_
 
 extern double sqrtk(double x, int iter);
 
-#endif /*_LIBC_MATH_H_*/
+#endif /*_LIBC_SQRTK_H_*/


### PR DESCRIPTION
There was a typo in the #include guards in `sqrtk.h`:

```
#ifndef _LIBC_SQRTK_H_
#define _LIBC_MATH_H_

//...

#endif /*_LIBC_MATH_H_*/
```